### PR TITLE
Implement time-ago util and rename history type

### DIFF
--- a/src/app/(history)/read/capsule/[id]/CapsuleResult.tsx
+++ b/src/app/(history)/read/capsule/[id]/CapsuleResult.tsx
@@ -1,9 +1,9 @@
 import { CalendarIcon, OutlinedLocationIcon } from "@/components/icons";
 import Image from "next/image";
-import MessageType from "@/types/history.type";
+import HistoryType from "@/types/history.type";
 import { useAddressQuery } from "@/services/map/location.query";
 
-export default function CapsuleResult({ message }: { message: MessageType }) {
+export default function CapsuleResult({ message }: { message: HistoryType }) {
   const { data: address } = useAddressQuery(message.lat, message.lng);
   return (
     <div className="flex w-full flex-col items-center gap-16 p-10">

--- a/src/app/(history)/read/capsule/[id]/CapsuleResult.tsx
+++ b/src/app/(history)/read/capsule/[id]/CapsuleResult.tsx
@@ -1,6 +1,6 @@
 import { CalendarIcon, OutlinedLocationIcon } from "@/components/icons";
 import Image from "next/image";
-import HistoryType from "@/types/history.type";
+import { HistoryType } from "@/types";
 import { useAddressQuery } from "@/services/map/location.query";
 
 export default function CapsuleResult({ message }: { message: HistoryType }) {

--- a/src/app/(history)/read/capsule/[id]/OpenAnimation.tsx
+++ b/src/app/(history)/read/capsule/[id]/OpenAnimation.tsx
@@ -1,12 +1,12 @@
 import CapsuleResult from "@/app/(history)/read/capsule/[id]/CapsuleResult";
 import { Capsule3DIcon } from "@/components/icons";
 import React, { useEffect, useState } from "react";
-import MessageType from "@/types/history.type";
+import HistoryType from "@/types/history.type";
 
 interface OpenAnimationProps {
   isMounted: boolean;
   setIsMounted: React.Dispatch<React.SetStateAction<boolean>>;
-  message: MessageType;
+  message: HistoryType;
 }
 
 export default function OpenAnimation({

--- a/src/app/(history)/read/capsule/[id]/OpenAnimation.tsx
+++ b/src/app/(history)/read/capsule/[id]/OpenAnimation.tsx
@@ -1,7 +1,7 @@
 import CapsuleResult from "@/app/(history)/read/capsule/[id]/CapsuleResult";
 import { Capsule3DIcon } from "@/components/icons";
 import React, { useEffect, useState } from "react";
-import HistoryType from "@/types/history.type";
+import { HistoryType } from "@/types";
 
 interface OpenAnimationProps {
   isMounted: boolean;

--- a/src/app/(tabs)/components/GoogleMapView.tsx
+++ b/src/app/(tabs)/components/GoogleMapView.tsx
@@ -10,13 +10,13 @@ import React, { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { circleOptions, mapOptions } from "@/constants";
 import { useWatchPosition } from "@/hooks";
-import { MessageType, Position, PositionType } from "@/types";
+import { HistoryType, Position, PositionType } from "@/types";
 import HistoryMarker from "./HistoryMarker";
 
 interface GoogleMapViewProps extends PositionType {
   mapRef: React.RefObject<google.maps.Map | null>;
   setPosition: React.Dispatch<React.SetStateAction<Position>>;
-  messageData: MessageType[];
+  messageData: HistoryType[];
 }
 
 export default function GoogleMapView({

--- a/src/app/(tabs)/components/HistoryItem.tsx
+++ b/src/app/(tabs)/components/HistoryItem.tsx
@@ -5,7 +5,8 @@ import {
   MessageIcon,
 } from "@/components/icons";
 import { useRemainTime } from "@/hooks";
-import { formatRemainTime } from "@/utils";
+import { useAddressQuery } from "@/services/map/location.query";
+import { extractCleanAddress, formatRemainTime, formatTimeAgo } from "@/utils";
 
 import { HistoryType } from "@/types";
 
@@ -17,6 +18,7 @@ interface HistoryItemProps {
 export default function HistoryItem({ history, onClick }: HistoryItemProps) {
   const { remainTime, isLocked } = useRemainTime(history.open_at!);
   const type = history.is_time_capsule ? "capsule" : "message";
+  const { data: address } = useAddressQuery(history.lat, history.lng);
 
   return (
     <div className="flex w-full items-center justify-between" onClick={onClick}>
@@ -50,11 +52,13 @@ export default function HistoryItem({ history, onClick }: HistoryItemProps) {
               <p className="truncate text-b2 text-black">
                 {history.is_anonymous ? "익명의 누군가" : history.nickname}
               </p>
-              <p className="text-cap1 text-gray-3">
-                {new Date(history.created_at).toLocaleString()}
+              <p className="text-cap1 text-gray-3" suppressHydrationWarning>
+                {formatTimeAgo(history.created_at)}
               </p>
             </div>
-            <p className="text-b3 text-gray-4">주소</p>
+            <p className="text-b3 text-gray-4">
+              {extractCleanAddress(address?.address_components)}
+            </p>
           </div>
 
           <ChevronIcon direction="right" color="#C3C3C3" />

--- a/src/app/(tabs)/history/FoundContainer.tsx
+++ b/src/app/(tabs)/history/FoundContainer.tsx
@@ -8,7 +8,7 @@ import {
   TrashIcon,
 } from "@/components/icons";
 import { useAddressQuery } from "@/services/map/location.query";
-import { MessageType } from "@/types";
+import { HistoryType } from "@/types";
 import { extractCleanAddress } from "@/utils";
 import Image from "next/image";
 
@@ -20,7 +20,7 @@ export default function FoundContainer({
   is_anonymous,
   created_at,
   nickname,
-}: MessageType) {
+}: HistoryType) {
   const { data: currentLocation } = useAddressQuery(lat, lng);
 
   return (

--- a/src/app/(tabs)/history/MineContainer.tsx
+++ b/src/app/(tabs)/history/MineContainer.tsx
@@ -8,7 +8,7 @@ import {
   TrashIcon,
 } from "@/components/icons";
 import { useAddressQuery } from "@/services/map/location.query";
-import { MessageType } from "@/types";
+import { HistoryType } from "@/types";
 import { extractCleanAddress } from "@/utils";
 
 export default function MineContainer({
@@ -17,7 +17,7 @@ export default function MineContainer({
   lat,
   lng,
   created_at,
-}: MessageType) {
+}: HistoryType) {
   const { data: currentLocation } = useAddressQuery(lat, lng);
 
   return (

--- a/src/services/message/api.ts
+++ b/src/services/message/api.ts
@@ -1,5 +1,5 @@
 import { supabase } from "@/lib/supabaseClient";
-import MessageType from "@/types/history.type";
+import HistoryType from "@/types/history.type";
 import { formatDateKSTForDB } from "@/utils";
 
 const RANGE = 0.00045;
@@ -7,7 +7,7 @@ const RANGE = 0.00045;
 export const getNearbyMessages = async (
   lat: number,
   lng: number
-): Promise<MessageType[]> => {
+): Promise<HistoryType[]> => {
   const {
     data: { session },
   } = await supabase.auth.getSession();
@@ -33,13 +33,13 @@ export const getNearbyMessages = async (
     : { data: [] };
   const readIds = views?.map((v) => v.message_id) ?? [];
   return (data || []).map((m: any) => ({
-    ...(m as Omit<MessageType, "nickname" | "read">),
+    ...(m as Omit<HistoryType, "nickname" | "read">),
     nickname: m.users.nickname,
     read: readIds.includes(m.id),
   }));
 };
 
-export const getMessage = async (id: string): Promise<MessageType> => {
+export const getMessage = async (id: string): Promise<HistoryType> => {
   const {
     data: { session },
   } = await supabase.auth.getSession();
@@ -62,10 +62,10 @@ export const getMessage = async (id: string): Promise<MessageType> => {
     : { data: null };
 
   return {
-    ...(data as Omit<MessageType, "nickname" | "read">),
+    ...(data as Omit<HistoryType, "nickname" | "read">),
     nickname: (data as any).users.nickname,
     read: !!view,
-  } as MessageType;
+  } as HistoryType;
 };
 
 export const createMessage = async ({
@@ -100,7 +100,7 @@ export const createMessage = async ({
     .select()
     .single();
   if (error) throw new Error(error.message);
-  return data as MessageType;
+  return data as HistoryType;
 };
 
 export const createCapsule = async ({
@@ -141,7 +141,7 @@ export const createCapsule = async ({
     .select()
     .single();
   if (error) throw new Error(error.message);
-  return data as MessageType;
+  return data as HistoryType;
 };
 
 export const readMessage = async (id: string) => {
@@ -156,7 +156,7 @@ export const readMessage = async (id: string) => {
     .insert([{ user_id: userId, message_id: id }]);
 };
 
-export const getMyMessages = async (): Promise<MessageType[]> => {
+export const getMyMessages = async (): Promise<HistoryType[]> => {
   const {
     data: { session },
   } = await supabase.auth.getSession();
@@ -171,13 +171,13 @@ export const getMyMessages = async (): Promise<MessageType[]> => {
 
   if (error) throw new Error(error.message);
   return (data || []).map((m: any) => ({
-    ...(m as Omit<MessageType, "nickname" | "read">),
+    ...(m as Omit<HistoryType, "nickname" | "read">),
     nickname: m.users.nickname,
     read: true,
   }));
 };
 
-export const getFoundMessages = async (): Promise<MessageType[]> => {
+export const getFoundMessages = async (): Promise<HistoryType[]> => {
   const {
     data: { session },
   } = await supabase.auth.getSession();
@@ -192,7 +192,7 @@ export const getFoundMessages = async (): Promise<MessageType[]> => {
 
   if (error) throw new Error(error.message);
   return (data || []).map((v: any) => ({
-    ...(v.message as Omit<MessageType, "nickname" | "read">),
+    ...(v.message as Omit<HistoryType, "nickname" | "read">),
     nickname: v.message.users.nickname,
     read: true,
   }));

--- a/src/types/history.type.ts
+++ b/src/types/history.type.ts
@@ -1,4 +1,4 @@
-interface MessageType {
+interface HistoryType {
   id: string;
   user_id: string;
   content: string;
@@ -13,4 +13,4 @@ interface MessageType {
   nickname: string;
 }
 
-export default MessageType;
+export default HistoryType;

--- a/src/utils/formatTimeAgo.ts
+++ b/src/utils/formatTimeAgo.ts
@@ -1,0 +1,18 @@
+export default function formatTimeAgo(date: string | number | Date): string {
+  const d = typeof date === "string" || typeof date === "number" ? new Date(date) : date;
+  const diff = Date.now() - d.getTime();
+
+  const minute = 60 * 1000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  const month = 30 * day;
+
+  if (diff < minute) return "방금 전";
+  if (diff < hour) return `${Math.floor(diff / minute)}분 전`;
+  if (diff < day) return `${Math.floor(diff / hour)}시간 전`;
+  if (diff < month) return `${Math.floor(diff / day)}일 전`;
+
+  const months = Math.floor(diff / month);
+  if (months < 12) return `${months}달 전`;
+  return `${Math.floor(months / 12)}년 전`;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -3,3 +3,4 @@ export { default as formatRemainTime } from "./formatRemainTime";
 export { default as formatInputDate } from "./formatInputDate";
 export { default as formatInputTime } from "./formatInputTime";
 export { default as formatDateKSTForDB } from "./formatDateKSTForDB";
+export { default as formatTimeAgo } from "./formatTimeAgo";


### PR DESCRIPTION
## Summary
- rename interface `MessageType` to `HistoryType`
- add `formatTimeAgo` utility for relative time
- show relative time and address in `HistoryItem`
- update components and APIs to use new `HistoryType`

## Testing
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68621258e524832aae68de3a80b80da5